### PR TITLE
Some improvements to examples/main.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,10 @@ The user can invoke their functions by sending:
 
 ## Function templates
 ```c
-cli_status_t user_uart_println(char *string)
+void user_uart_println(char *string)
 {
     /* For example.. */
-    if(HAL_UART_Transmit_IT(&huart, string, strlen(string)) != HAL_OK)
-        return SLI_E_IO;
-    
-    return SLI_OK;
+    HAL_UART_Transmit_IT(&huart, string, strlen(string));
 }
 
 cli_status_t help_func(int argc, char **argv)

--- a/examples/main.c
+++ b/examples/main.c
@@ -34,16 +34,17 @@ int main(void)
     return 0;
 }
 
+/* For example.. */
 void UART_Rx_IrqHandler()
 {
     char c = UART->RxData;
     cli_put(&cli, c);
 }
 
-cli_status_t user_uart_println(char *string)
+void user_uart_println(char *string)
 {
-    printf(string);
-    return SLI_OK;
+    /* For example.. */
+    HAL_UART_Transmit_IT(&huart, string, strlen(string));
 }
 
 cli_status_t help_func(int argc, char **argv)


### PR DESCRIPTION
examples/main.c doesn't have function signatures to match the actual library or ReadMe, and the return values are missing.
Also it has no reference to calling cli_put(), which is essential for using this library, and this confused me initially so I thought it would be useful to include this in the code sample.