### PR TITLE
flag from cli_put() to cli_process() to indicate new command has been entered

### DIFF
--- a/cli_defs.h
+++ b/cli_defs.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 
 #define MAX_BUF_SIZE        128     /* Maximum size of CLI Rx buffer */ 
-#define CMD_TERMINATOR      '\r'    /* Delimitor denoting end of cmd */
+#define CMD_TERMINATOR      '\r'    /* Delimiter denoting end of cmd from user */
 
 typedef enum
 {
@@ -13,7 +13,8 @@ typedef enum
     CLI_E_IO,
     CLI_E_CMD_NOT_FOUND,    /* Command name not found in command table. */
     CLI_E_INVALID_ARGS,     /* Invalid function parameters/arguments.   */
-    CLI_E_BUF_FULL          /* CLI buffer full.                         */
+    CLI_E_BUF_FULL,         /* CLI buffer full.                         */
+	CLI_IDLE                /* No command to execute at the moment      */
 } cli_status_t;
 
 /*!


### PR DESCRIPTION
These are the changes I made to deal with issue #3 and #4, and make the library work the way it seemed it was meant to.
cli_process() now does nothing until the cmd_pending flag is set by cli_put().  To prevent the command buffer being changed while cli_process() is using it, cli_put() ignores command terminators until the cmd_pending flag is cleared again by cli_process().
But if I've just misunderstood the way the code was meant to be used, let me know!